### PR TITLE
Login

### DIFF
--- a/js/content_under_half.js
+++ b/js/content_under_half.js
@@ -45,7 +45,7 @@ function login(){
 		 $.waitFor('.lms-StandardLogin_Username',function(){
 			$('.lms-StandardLogin_Username').val(localStorage.usuario_bet365);
 			$('.lms-StandardLogin_Password ').val(localStorage.senha_bet365);
-			$('.lms-StandardLogin_LoginButton ').click();
+			$('.lms-LoginButton_Text ').click();
 		});
 	}
 	


### PR DESCRIPTION
Identificador da classe do botão de Login mudou de nome. Por conta disso não era possível fazer o login de maneira automática. 
Nome antigo: "lms-StandardLogin_LoginButton ". 
Nome atual: "lms-LoginButton_Text ".